### PR TITLE
version upgrades

### DIFF
--- a/generators/app/templates/_Dockerfile
+++ b/generators/app/templates/_Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 ENV JHIPSTER_SLEEP 0
 

--- a/generators/app/templates/src/main/docker/_Tomcat.Dockerfile
+++ b/generators/app/templates/src/main/docker/_Tomcat.Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0.36-jre8-alpine
+FROM tomcat:8-jre8-alpine
 
 ENV JHIPSTER_SLEEP 0
 ENV TOMCAT_PASSWORD JH!pst3r


### PR DESCRIPTION
- Migrate from java to OpenJDK image
- Change Tomcat image label to receive correction fixes in tomcat 8.0 branch

I changed the tomcat label so that it points to this: https://github.com/docker-library/tomcat/blob/master/8.0/jre8-alpine/Dockerfile
