### PR TITLE
Get JHipster App Config correctly

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -21,7 +21,7 @@ module.exports = class extends BaseGenerator {
     get initializing() {
         return {
             readConfig() {
-                this.jhipsterAppConfig = this.getJhipsterAppConfig();
+                this.jhipsterAppConfig = this.getAllJhipsterConfig();
                 if (!this.jhipsterAppConfig) {
                     this.error('Can\'t read .yo-rc.json');
                 }


### PR DESCRIPTION
If you executed the code with JHipster 6.1.2, you got an error: "this.getJhipsterAppConfig is not a function"

Solution is to replace it with "this.getAllJhipsterConfig()" (see (https://stackoverflow.com/questions/56191820/jhipster-ionic-error-while-creating-app-getjhipsterappconfig-is-not-a-function)) 